### PR TITLE
fix: add  judge of empty args

### DIFF
--- a/frontend/src/views/SoftSettings/controller/index.tsx
+++ b/frontend/src/views/SoftSettings/controller/index.tsx
@@ -220,7 +220,11 @@ function formatEnv(val: Record<string, string>) {
  * @returns {string[]} 恢复后的参数值
  */
 function receveArgs(val: string) {
-	return val.split('\n');
+	if (val) {
+		return val.split('\n');
+	} else {
+		return []
+	}
 }
 /**
  * @description 恢复环境变量


### PR DESCRIPTION
empty args will be handle as empty string like ['']  some mcp server will report error